### PR TITLE
Freeze dependencies

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: "Dependency Review"
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v3
+      - name: "Dependency Review"
+        uses: actions/dependency-review-action@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+beautifulsoup4==4.11.1
+certifi==2022.12.7
+charset-normalizer==3.0.1
+html5lib==1.1
+idna==3.4
+PySimpleGUI==4.60.4
+requests==2.28.2
+six==1.16.0
+soupsieve==2.3.2.post1
+tqdm==4.64.1
+urllib3==1.26.14
+webencodings==0.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,11 +7,11 @@ description-file = README.md
 packages = find:
 python_requires = >=3.8
 install_requires =
-    PySimpleGUI
-    beautifulsoup4
-    html5lib
-    requests
-    tqdm
+    PySimpleGUI==4.60.4
+    beautifulsoup4==4.11.1
+    html5lib==1.1
+    requests==2.28.2
+    tqdm==4.64.1
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
I think freezing the dependencies needed to install the package might be a good idea.
To my knowledge dependabot checks `requirements.txt` for dependencies. 
That is why in addition to the dependencies being specified in `setup.cfg` I added them in the `requirements.txt` with transitive dependencies.